### PR TITLE
[Backend:Add] Create article,article_comments,article_comment_replies…

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,8 +1,19 @@
 class ApplicationController < ActionController::API
     include ActionController::Cookies
+    rescue_from ActiveRecord::RecordNotFound, with: :render_not_found
+    rescue_from ActiveRecord::RecordInvalid, with: :render_invalid
 
-    def index
-        puts("ADmin is now created")
-        puts("Test successful")
-    end
+private
+
+#Handle record missing
+def render_not_found(exception)
+    render json:{errors:exception}, status: :not_found
+end
+
+#Handle invalid
+def render_invalid(exception)
+    render json:{errors:exception.record.errors.full_messages}
+end
+
+    
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,19 +1,3 @@
 class ApplicationController < ActionController::API
     include ActionController::Cookies
-    rescue_from ActiveRecord::RecordNotFound, with: :render_not_found
-    rescue_from ActiveRecord::RecordInvalid, with: :render_invalid
-
-private
-
-#Handle record missing
-def render_not_found(exception)
-    render json:{errors:exception}, status: :not_found
-end
-
-#Handle invalid
-def render_invalid(exception)
-    render json:{errors:exception.record.errors.full_messages}
-end
-
-    
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,19 @@
 class ApplicationController < ActionController::API
     include ActionController::Cookies
+    rescue_from ActiveRecord::RecordNotFound, with: :render_not_found
+    rescue_from ActiveRecord::RecordInvalid, with: :render_invalid
+
+    private
+
+    #Handle record missing
+    def render_not_found(exception)
+        render json:{errors:exception}, status: :not_found
+    end
+
+    #Handle invalid
+    def render_invalid(exception)
+        render json:{errors:exception.record.errors.full_messages}
+    end
+
+    
 end

--- a/app/controllers/article_comment_replies_controller.rb
+++ b/app/controllers/article_comment_replies_controller.rb
@@ -1,0 +1,42 @@
+class ArticleCommentRepliesController < ApplicationController
+    #GET /article_comment_replies
+    def index
+        render json: ArticleCommentRepliesController.all
+    end
+
+    #GET /article_comment_replies
+    def show
+        render json:find_article_reply
+    end
+    #POST /article_comment_replies
+    def create
+        article_comment_reply  = ArticleCommentRepliesController.create!(article_comment_reply_params)
+        render json: article_comment_reply
+    end
+
+    #PATCH /article_comment_replies/:id
+    def show
+        article_comment_reply = find_article_reply
+        article_comment_reply.update!(article_comment_reply_params)
+        render json: article_comment_reply, status: :accepted
+    end
+
+    #DELETE /article_comment_replies/:id
+    def destroy
+        article_comment_reply = find_article_reply
+        article_comment_reply.destroy
+        head :no_content
+    end
+
+    private
+    #find one reply
+    def find_article_reply
+       article_comment_reply = ArticleCommentRepliesController.find(params[:id])
+    end
+    
+    #Permit params
+    def article_comment_reply_params
+        params.permit(:likes,:user_id,:article_id,:reply)
+    end
+
+end

--- a/app/controllers/article_comments_controller.rb
+++ b/app/controllers/article_comments_controller.rb
@@ -1,0 +1,43 @@
+class ArticleCommentsController < ApplicationController
+    #GET /article_comments
+    def index        
+        render json:ArticleComment.all
+    end
+
+    #GET /article_comments/:id
+    def show
+        article_comment = find_a_comment
+        render json:article_comment
+    end
+
+    #POST /article_comments
+    def create
+        article_comment = ArticleComment.create!(article_comment_params)
+        render json: article_comment
+    end
+
+    #PATCH /article_comments/:id
+    def update
+        article_comment = find_a_comment
+        article_comment.update!(article_comment_params)
+        render json:article_comment, status: :accepted
+    end
+
+    #DELETE /article_comments/:id
+    def destroy
+      article_comment = find_a_comment
+      article_comment.destroy
+      head :no_content
+    end
+
+    private
+    #permit params
+    def article_comment_params
+        params.permit(:user_id,:post_id,:comment,:likes)
+    end
+
+    #find an article comment
+    def find_a_comment
+        article_comment = ArticleComment.find(params[:id])
+    end
+end

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -1,0 +1,44 @@
+class ArticlesController < ApplicationController
+    #GET /articles
+    def index
+        render json: Article.all
+    end
+
+    #GET /articles/:id
+    def show
+        article = find_an_article
+        render json: article
+    end
+
+    #POST /articles
+    def create
+        article  = Article.create!(article_params)
+        render json: article, status: :created
+    end
+
+    #PATCH /articles/:id
+    def update
+        article = find_an_article
+        article.update!(article_params)
+        render json: article, status: :accepted
+    end
+
+    #DELETE /articles/:id
+    def destroy
+        article = find_an_article
+        article.destroy
+        head :no_content
+    end
+
+    private
+    #fetch a single article
+    def find_an_article
+       articles = Article.find(params[:id])
+    end
+
+    #permit params
+    def article_params
+      params.permit(:title, :content,:is_approved,:likes,:is_flagged,:category_id)
+    end
+    
+end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,0 +1,7 @@
+class Article < ApplicationRecord
+    validates :title, :content,:is_approved,:likes,:is_flagged, presence: true
+    validates :content,length:{minimum: 250}
+    validates :title, uniqueness: true
+    has_many :article_comments
+    #belongs_to :user
+end

--- a/app/models/article_comment.rb
+++ b/app/models/article_comment.rb
@@ -1,0 +1,4 @@
+class ArticleComment < ApplicationRecord
+    validates :comment,:user_id,:article_id,:likes, presence: true
+    belongs_to :article
+end

--- a/app/models/article_comment_reply.rb
+++ b/app/models/article_comment_reply.rb
@@ -1,0 +1,5 @@
+class ArticleCommentReply < ApplicationRecord
+    vaildates :user_id,:article_comment_id,:reply,:likes, presence: true
+    belongs_to :article_comment
+    belongs_to :user
+end

--- a/app/serializers/article_comment_reply_serializer.rb
+++ b/app/serializers/article_comment_reply_serializer.rb
@@ -1,0 +1,3 @@
+class ArticleCommentReplySerializer < ActiveModel::Serializer
+  attributes :id, :likes, :reply, :user_id,:article_comment_id
+end

--- a/app/serializers/article_comment_serializer.rb
+++ b/app/serializers/article_comment_serializer.rb
@@ -1,0 +1,3 @@
+class ArticleCommentSerializer < ActiveModel::Serializer
+  attributes :id, :comment, :likes
+end

--- a/app/serializers/article_serializer.rb
+++ b/app/serializers/article_serializer.rb
@@ -1,0 +1,3 @@
+class ArticleSerializer < ActiveModel::Serializer
+  attributes :id, :title, :content, :is_approved, :likes, :is_flagged
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,5 @@
 Rails.application.routes.draw do
-  resources :article_comment_replies
-  resources :article_comments
-  resources :articles
+  resources :students
   resources :staffs
   resources :admins, only: [:index]
   

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,7 @@
 Rails.application.routes.draw do
+  resources :article_comment_replies
+  resources :article_comments
+  resources :articles
   resources :staffs
   resources :admins, only: [:index]
   

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
-  resources :students
+  resources :article_comment_replies
+  resources :article_comments
+  resources :articles
   resources :staffs
   resources :admins, only: [:index]
   

--- a/db/migrate/20221019164706_create_articles.rb
+++ b/db/migrate/20221019164706_create_articles.rb
@@ -1,0 +1,15 @@
+class CreateArticles < ActiveRecord::Migration[7.0]
+  def change
+    create_table :articles do |t|
+      t.string :title
+      t.string :content
+      t.boolean :is_approved
+      t.integer :likes
+      t.boolean :is_flagged
+     #t.belongs_to :category,null:false, foreign_key:true
+     #t.belongs_to :user,null: false,foreign_key:true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20221019201259_create_article_comments.rb
+++ b/db/migrate/20221019201259_create_article_comments.rb
@@ -1,0 +1,11 @@
+class CreateArticleComments < ActiveRecord::Migration[7.0]
+  def change
+    create_table :article_comments do |t|
+      t.string :comment
+      t.string :likes
+      t.belongs_to :article, null:false, foreign_key:true
+      #t.integer :user, null:false, foreign_key:true
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20221019214407_create_article_comment_replies.rb
+++ b/db/migrate/20221019214407_create_article_comment_replies.rb
@@ -1,0 +1,11 @@
+class CreateArticleCommentReplies < ActiveRecord::Migration[7.0]
+  def change
+    create_table :article_comment_replies do |t|
+      t.integer :likes
+      t.string :reply
+      t.belongs_to :user, null:false, foreign_key:true
+      t.belongs_to :article_comment,null:false, foreign_key:true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_10_19_164825) do
+ActiveRecord::Schema[7.0].define(version: 2022_10_19_201259) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -22,21 +22,27 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_19_164825) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "staffs", force: :cascade do |t|
-    t.string "first_name"
-    t.string "last_name"
-    t.string "email"
-    t.string "password_digest"
+  create_table "article_comments", force: :cascade do |t|
+    t.string "comment"
+    t.string "likes"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "students", force: :cascade do |t|
+  create_table "articles", force: :cascade do |t|
+    t.string "title"
+    t.string "content"
+    t.boolean "is_approved"
+    t.integer "likes"
+    t.boolean "is_flagged"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "staffs", force: :cascade do |t|
     t.string "first_name"
     t.string "last_name"
     t.string "email"
-    t.string "avatar_url"
-    t.string "username"
     t.string "password_digest"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_10_19_201259) do
+ActiveRecord::Schema[7.0].define(version: 2022_10_19_164825) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -22,27 +22,21 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_19_201259) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "article_comments", force: :cascade do |t|
-    t.string "comment"
-    t.string "likes"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-  end
-
-  create_table "articles", force: :cascade do |t|
-    t.string "title"
-    t.string "content"
-    t.boolean "is_approved"
-    t.integer "likes"
-    t.boolean "is_flagged"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-  end
-
   create_table "staffs", force: :cascade do |t|
     t.string "first_name"
     t.string "last_name"
     t.string "email"
+    t.string "password_digest"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "students", force: :cascade do |t|
+    t.string "first_name"
+    t.string "last_name"
+    t.string "email"
+    t.string "avatar_url"
+    t.string "username"
     t.string "password_digest"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_10_19_131703) do
+ActiveRecord::Schema[7.0].define(version: 2022_10_19_201259) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -18,6 +18,23 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_19_131703) do
     t.string "first_name"
     t.string "last_name"
     t.string "password_digest"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "article_comments", force: :cascade do |t|
+    t.string "comment"
+    t.string "likes"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "articles", force: :cascade do |t|
+    t.string "title"
+    t.string "content"
+    t.boolean "is_approved"
+    t.integer "likes"
+    t.boolean "is_flagged"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end


### PR DESCRIPTION
The posts table was split into 3. As a result, we will end up with 3 tables to store the content: i.e articles, audio, and videos. As a result, to maintain a clean association between posts and their comments, each type of content will have its own type of comment table e.g article_comments, audio_comments. As a result, the comments replies table splits into three each for each category of the comments. i.e audio_comments_replies, video_comment_replies.
These proposed changes are for the article type of content.